### PR TITLE
fixed sending files containing lines with only "]]".

### DIFF
--- a/ESPlorer/src/ESPlorer/ESPlorer.java
+++ b/ESPlorer/src/ESPlorer/ESPlorer.java
@@ -10111,7 +10111,7 @@ public class ESPlorer extends javax.swing.JFrame {
         sendBuf.add("w = file.writeline\r\n");
         s = TextEditor1.get(iTab).getText().split("\r?\n");
         for(String subs : s) {
-            sendBuf.add("w([[" + subs + "]]);");
+            sendBuf.add("w([==[" + subs + "]==]);");
         }
         sendBuf.add("file.close();");
         if (FileAutoRun.isSelected()) {


### PR DESCRIPTION
In the 4refr0nt/luatool@e297d99489204c9514f6c515ad978ef7d99ad48d files are transmitted via `[==[line]==]`, which enables the transmission of files containing lines, which do consist itself out of `]]` lines. Consider the scenario, a line consists of the content `]])`. Using the old code, the command would result in an error, as it is called like `w([[]])]])`. With this improvement it is transmitted as `w([==[]])]==])` not resulting in an error.