### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ ESPlorer
 ========
 
 [![Join the chat at https://gitter.im/4refr0nt/ESPlorer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/4refr0nt/ESPlorer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-####Integrated Development Environment (IDE) for ESP8266 developers
+#### Integrated Development Environment (IDE) for ESP8266 developers
 
-###Package Description
+### Package Description
 The essential multiplatforms tools for any ESP8266 developer from luatool author’s, including a LUA for NodeMCU and MicroPython. Also, all AT commands are supported.
 
 Required [JAVA](http://java.com/download) (Standard Edition - SE ver 7 and above) installed.
 
-###Supported platforms
+### Supported platforms
 - Windows(x86, x86-64)
 - Linux(x86, x86-64, ARM soft & hard float)
 - Solaris(x86, x86-64)
 - Mac OS X(x86, x86-64, PPC, PPC64)
 
-###Detailed features list
+### Detailed features list
 - Syntax highlighting LUA and Python code
 - Code editor color themes: default, dark, Eclipse, IDEA, Visual Studio
 - Undo/Redo editors features
@@ -26,19 +26,19 @@ Required [JAVA](http://java.com/download) (Standard Edition - SE ver 7 and above
 - Detailed logging
 - and more, more more…
 
-###Required libraries for build
+### Required libraries for build
 * [jSSC](https://code.google.com/p/java-simple-serial-connector/)
 * [rSyntaxTextArea](http://bobbylight.github.io/RSyntaxTextArea/)
 
-###Discuss
+### Discuss
 * [English esp8266.com](http://www.esp8266.com/viewtopic.php?f=22&t=882)
 * [Russian esp8266.ru](http://esp8266.ru/forum/threads/esplorer.34/)
 
-###Home Page
+### Home Page
 [http://esp8266.ru/ESPlorer/](http://esp8266.ru/esplorer/)
 
-###Latest binaries download
+### Latest binaries download
 [esp8266.ru](http://esp8266.ru/esplorer/#download)
 
-###How to build ESPlorer from sources
+### How to build ESPlorer from sources
 [ESPlorer build from sources](https://github.com/devyte/nodemcu-platform/wiki/How-to-build-ESPlorer-from-sources), howto from devyte


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
