### PR TITLE
Enable 'AutoRun after save' checkbox (fixes #34)

### DIFF
--- a/ESPlorer/src/ESPlorer/ESPlorer.form
+++ b/ESPlorer/src/ESPlorer/ESPlorer.form
@@ -4459,7 +4459,6 @@
                                     </Property>
                                     <Property name="text" type="java.lang.String" value="AutoRun file after save to ESP"/>
                                     <Property name="toolTipText" type="java.lang.String" value=""/>
-                                    <Property name="enabled" type="boolean" value="false"/>
                                     <Property name="horizontalAlignment" type="int" value="2"/>
                                     <Property name="horizontalTextPosition" type="int" value="4"/>
                                   </Properties>

--- a/ESPlorer/src/ESPlorer/ESPlorer.java
+++ b/ESPlorer/src/ESPlorer/ESPlorer.java
@@ -2925,7 +2925,6 @@ public class ESPlorer extends javax.swing.JFrame {
         FileAutoRun.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         FileAutoRun.setText("AutoRun file after save to ESP");
         FileAutoRun.setToolTipText("");
-        FileAutoRun.setEnabled(false);
         FileAutoRun.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         FileAutoRun.setHorizontalTextPosition(javax.swing.SwingConstants.RIGHT);
         FileAutoRun.addItemListener(new java.awt.event.ItemListener() {


### PR DESCRIPTION
Enable the `AutoRun file after save to ESP` checkbox in the settings view, so a user can check or uncheck this option again. This should fix #34 