### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Download the latest and greatest one from [Oracle website](https://www.oracle.co
 [http://esp8266.ru/ESPlorer/](http://esp8266.ru/esplorer/)
 
 ### Latest binaries download
-[esp8266.ru](http://esp8266.ru/esplorer/#download)
+Check out [Releases](https://github.com/4refr0nt/ESPlorer/releases)
 
 ### Build from sources
 #### Windows

--- a/src/main/java/ESPlorer/ESPlorer.java
+++ b/src/main/java/ESPlorer/ESPlorer.java
@@ -47,7 +47,7 @@ public class ESPlorer extends javax.swing.JFrame {
     public static boolean pOpen = false;
     public static boolean sOpen = false;
     public static boolean portJustOpen = false;
-    public static final String VERSION = "v0.2.0-rc5";
+    public static final String VERSION = "v0.2.0";
     private static String laf;
     private static String systemLaf;
     public static Preferences prefs;


### PR DESCRIPTION
Hi Victor!
I suggest releasing the app "as is" using version number 0.2.0 and publish the binary at the github page instead of project website.
That way the binary will be closer to the source code and should be looking more trustworthy for the users.
Let's start using semantic versioning (a.b.c - increment c for bugfixes, b - in case of new features, a - major changes) and stop using "-rcX" suffixes?
