### PR TITLE
Update jssc lib to 2.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.github.java-native</groupId>
             <artifactId>jssc</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.4</version>
         </dependency>
         <dependency>
             <groupId>com.fifesoft</groupId>


### PR DESCRIPTION
jssc 2.9.2 does'nt detect serial ports on Mac OS X but 2.9.4 does.